### PR TITLE
fix hoaproject/Central#69 for Acl (removing hhvm)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,6 @@ matrix:
       env:
         - ENABLE_DEVTOOLS=true
     - php: nightly
-    - php: hhvm-3.12
-      sudo: required
-      dist: trusty
-      group: edge
-    - php: hhvm
-      sudo: required
-      dist: trusty
-      group: edge
   allow_failures:
     - php: nightly
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ matrix:
       group: edge
   allow_failures:
     - php: nightly
-    - php: hhvm-3.12
-    - php: hhvm
   fast_finish: true
 
 os:


### PR DESCRIPTION
fix hoaproject/Central#69 for Acl to remove HHVM support from travis build